### PR TITLE
feat: set wallpaper for multi-monitor setup

### DIFF
--- a/files/bin/autostart.sh
+++ b/files/bin/autostart.sh
@@ -26,7 +26,7 @@ ksuperkey -e 'Super_L=Alt_L|F1' &
 ksuperkey -e 'Super_R=Alt_L|F1' &
 
 # Restore wallpaper
-hsetroot -cover ~/.config/i3/wallpapers/default.png
+hsetroot -root -cover ~/.config/i3/wallpapers/default.png
 
 # Lauch notification daemon
 ~/.config/i3/bin/i3dunst.sh


### PR DESCRIPTION
By default, second screens simply have a black screen.
Passing in the `-root` option to `hsetroot` sets the same wallpaper across all the screens.