### PR TITLE
updated files/scripts/i3_autostart to support lockscreen with suspend

### DIFF
--- a/files/scripts/i3_autostart
+++ b/files/scripts/i3_autostart
@@ -47,3 +47,7 @@ hsetroot -root -cover "$idir"/theme/wallpaper
 
 # Start mpd
 exec mpd &
+
+# For Lock Scren
+
+xss-lock  --transfer-sleep-lock -- bettrlockscreen --nofork


### PR DESCRIPTION
betterlockscreen works perfectly before the update but after doing the "pacman -Syu" and upgrading the system , the system no longer locks and i have to install "xfce4-screensaver" in order to get a lock screen .I think this one line can fix the problem