### PR TITLE
fix(polybar): multiple devices flicker, added icons

### DIFF
--- a/files/theme/polybar/scripts/bluetooth.sh
+++ b/files/theme/polybar/scripts/bluetooth.sh
@@ -4,9 +4,9 @@
 
 # Colors
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-CDIR=`cd "$DIR" && cd .. && pwd`
-POWER_ON=`cat $CDIR/colors.ini | grep 'GREEN' | head -n1 | cut -d '=' -f2 | tr -d ' '`
-POWER_OFF=`cat $CDIR/colors.ini | grep 'ALTFOREGROUND' | head -n1 | cut -d '=' -f2 | tr -d ' '`
+CDIR=$(cd "$DIR" && cd .. && pwd)
+POWER_ON=$(grep 'GREEN' < "$CDIR"/colors.ini | head -n1 | cut -d '=' -f2 | tr -d ' ')
+POWER_OFF=$(grep 'ALTFOREGROUND' < "$CDIR"/colors.ini | head -n1 | cut -d '=' -f2 | tr -d ' ')
 
 # Checks if bluetooth controller is powered on
 power_on() {
@@ -31,7 +31,7 @@ device_connected() {
 # Useful for status bars like polybar, etc.
 print_status() {
     if power_on; then
-		if [[ -z `bluetoothctl info "$device" | grep "Alias" | cut -d ' ' -f 2-` ]]; then
+		if [[ -z $(bluetoothctl info "$device" | grep "Alias" | cut -d ' ' -f 2-) ]]; then
 			echo "%{F$POWER_ON}%{T2}%{T-} %{F-}On"
 		fi
 		
@@ -43,20 +43,48 @@ print_status() {
 
         mapfile -t paired_devices < <(bluetoothctl $paired_devices_cmd | grep Device | cut -d ' ' -f 2)
         counter=0
+        icons=""
 
         for device in "${paired_devices[@]}"; do
             if device_connected "$device"; then
                 device_alias=$(bluetoothctl info "$device" | grep "Alias" | cut -d ' ' -f 2-)
+                device_type=$(bluetoothctl info "$device" | grep "Icon" | cut -d ' ' -f 2-)
 
-                if [ $counter -gt 0 ]; then
-                    echo "%{F$POWER_ON}%{T2}%{T-} %{F-}$device_alias"
-                else
-                    echo "%{F$POWER_ON}%{T2}%{T-} %{F-}$device_alias"
-                fi
-
+                case $device_type in
+                    "input-mouse")
+                        icons="$icons | 󰍽"
+                        ;;
+                    "audio-headset")
+                        icons="$icons | 󰋎"
+                        ;;
+                    "audio-headphones")
+                        icons="$icons | "
+                        ;;
+                    "audio-card" | "audio-speaker")
+                        icons="$icons | 󰓃"
+                        ;;
+                    "input-keyboard")
+                        icons="$icons | 󰌌"
+                        ;;
+                    "input-gaming")
+                        icons="$icons | 󰖺"
+                        ;;
+                    "phone")
+                        icons="$icons | "
+                        ;;
+                    *)
+                        icons="$icons | $device_type"
+                esac
                 ((counter++))
             fi
         done
+        icons=$(echo "$icons" | cut -c3-)
+
+        if [[ $counter -gt 1 ]]; then
+            echo "%{F$POWER_ON}%{T2}%{T-} %{F-}$icons"
+        elif [[ $counter -gt 0 ]]; then
+            echo "%{F$POWER_ON}%{T2}%{T-} %{F-}$icons | $device_alias"
+        fi
     else
         echo "%{F$POWER_OFF}%{T2}%{T-} Off%{F-}"
     fi


### PR DESCRIPTION
Hello! Thanks for this awesome arch flavor!
If you don't mind I would like to suggest this PR for bluetooth widget in polybar
I hope you'll like this solution more than suggested in archcraft-os/archcraft-i3wm#10

This PR fixes flickering problem when multiple devices connected and also adds new feature:

If only one device connected: Show icon according to device type and it's alias
If >1 devices connected: Show only icons according to their device type
I didn't cover every single type of device, but I believe it should be enough

Result:
1 device
![image](https://github.com/user-attachments/assets/8f3b04ed-564b-47a1-9525-32e2f381fcb8)

\>1 device
![image](https://github.com/user-attachments/assets/a9f6416b-0f84-4256-a69b-b97073a72e77)
